### PR TITLE
Simplify the runtime import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rollup({
         // The module ID of the Handlebars runtime, exporting `Handlebars` as `default`.
         // As a shortcut, you can pass this as the value of `handlebars` above.
         // See the "Handlebars" section below.
-        id: 'handlebars', // Default: the path of Handlebars' UMD definition within this module
+        id: 'handlebars', // Default: the path of Handlebars' CJS definition within this module
 
         // Options to pass to Handlebars' `parse` and `precompile` methods.
         options: {
@@ -145,7 +145,7 @@ The advantage of the latter is that compatibility is
 guaranteed between the compiler and the runtime (see #6
 [here](https://github.com/wycats/handlebars.js/blob/8517352e209569f5a373d7a61ef4a673582d9616/FAQ.md)).
 
-The tradeoff is that the plugin's copy of the runtime is a UMD module, so to load such you'll also
+The tradeoff is that the plugin's copy of the runtime is a CJS module, so to load such you'll also
 need to install `rollup-plugin-node-resolve` and `rollup-plugin-commonjs`:
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 var Handlebars = require('handlebars');
 var ImportScanner = require('./ImportScanner');
 
-// The default module ID of the Handlebars runtime--the path of its UMD definition within this module.
-var DEFAULT_HANDLEBARS_ID = 'rollup-plugin-handlebars-plus/node_modules/handlebars/dist/handlebars.runtime.js';
+// The default module ID of the Handlebars runtime--the path of its CJS definition within this module.
+var DEFAULT_HANDLEBARS_ID = 'rollup-plugin-handlebars-plus/node_modules/handlebars/runtime';
 
 /**
  * Constructs a Rollup plugin to compile Handlebars templates.


### PR DESCRIPTION
The “handlebars/runtime” alias is supported/recommended for CommonJS
bundlers: https://github.com/wycats/handlebars.js/blob/71690ae39d1913e7f58635494859400fb54553d7/runtime.js#L2