### PR TITLE
Expose the default runtime ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ rollup({
 })
 ```
 
+In case you need the default runtime ID, it's available as `handlebars.runtimeId`. This might be
+useful if you want to import the runtime for use by templates precompiled by something other than
+this plugin. In that case, you'll have to make sure that the other compiler's version is compatible
+with this runtime.
+
 ### jQuery
 
 At Mixmax we often find it convenient to render templates to [jQuery](https://jquery.com/) collections

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 var Handlebars = require('handlebars');
 var ImportScanner = require('./ImportScanner');
+var path = require('path');
 
 // The default module ID of the Handlebars runtime--the path of its CJS definition within this module.
-var DEFAULT_HANDLEBARS_ID = 'rollup-plugin-handlebars-plus/node_modules/handlebars/runtime';
+// Note that it needs to be relative to our consumer's `node_modules` directory not absolute, or
+// else we'll bypass the `rollup-plugin-commonjs` configuration of `include: 'node_modules/**'`
+// and `rollup-plugin-babel` configuration of `exclude: 'node_modules/**'`.
+var consumerNodeModules = path.join(__dirname, '../..');
+var DEFAULT_HANDLEBARS_ID = path.relative(consumerNodeModules, require.resolve('handlebars/runtime'));
 
 /**
  * Constructs a Rollup plugin to compile Handlebars templates.
@@ -115,5 +120,8 @@ function handlebars(options) {
     }
   };
 }
+
+// In case the consumer needs it.
+handlebars.runtimeId = DEFAULT_HANDLEBARS_ID;
 
 module.exports = handlebars;


### PR DESCRIPTION
So that consumers can import the default runtime for use by templates not
precompiled by this plugin.