### PR TITLE
Fix partial import to work with rollup-plugin-root-import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,11 @@ function handlebars(options) {
 
       for (var partial of scanner.partials) {
         // Register the partial dependencies as partials.
-        body += `import '${partial}${options.templateExtension}';\n`;
+        // do not import special partial @partial-block: http://handlebarsjs.com/partials.html#partial-block
+        if (!partial.startsWith('@')) {
+          // rollup-plugin-root-import require import from '/'
+          body += `import '/${partial}${options.templateExtension}';\n`;
+        }
       }
 
       body += `var Template = Handlebars.template(${template});\n`;


### PR DESCRIPTION
Hi, I came across an issue that prevents cooperation between rollup-plugin-root-import and this plugin.
rollup-plugin-root-import will resolve only paths starting with '/' 

Add @partial-block handling - this probably could be solved better by using handlebars api - maybe it provides some metadata about partial type.

