### PR TITLE
Support use with rollup-plugin-uglify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function handlebars(options) {
       }
 
       body += `export default function(data, options, asString) {\n`;
-      body += `  const html = Template(data, options);\n`;
+      body += `  var html = Template(data, options);\n`;
       body += `  return (asString || (typeof $ === 'undefined')) ? html : $(html);\n`;
       body += `};\n`;
 


### PR DESCRIPTION
The `const` doesn't have much of an effect here and this change would allow easier use with rollup-plugin-uglify.