### PR TITLE
prevents DOM elements is jQuery exists globally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ function handlebars(options) {
 
       body += `export default function(data, options, asString) {\n`;
       body += `  var html = Template(data, options);\n`;
-      body += `  return (asString || (typeof $ === 'undefined')) ? html : $(html);\n`;
+      body += `  return (asString || ${!options.jquery}) ? html : $(html);\n`;
       body += `};\n`;
 
       return {


### PR DESCRIPTION
Hello!
We have a use case in which:
* we want templates as strings
* we have a globally defined jQuery instance 

In this scenario, templates are always rendered as string and the (absence of) the `jquery` option is ignored.

So I propose that in addition to conditionally import jQuery if the option is present, the conversion to DOM elements should also follow the option, and as such, avoids a "leaked" global `$` property.