### PR TITLE
feat: add more output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,32 @@ rollup({
 Curious about how to ID jQuery when it's a global i.e. you're _not_ bundling it?
 [Here's a Gist for that.](https://gist.github.com/wearhere/a3684edd54787b698029e42ea6ccc0f3)
 
-In case you want to render to a string even when using this option, all precompiled template functions
-have the signature `(data, options, asString)` so you can do:
+In case you want to render to a string even when using this option, all precompiled template
+functions support an additional `format` option so you can do:
 
 ```js
 import Template from './index.html';
 
-console.log(Template({}, {}, true));
+console.log(Template({}, { format: 'string' }));
+```
+
+### Fragments and Elements
+
+It can also be helpful to render a template to a `DocumentFragment`, which is supported by the
+`format` option:
+
+```js
+import Template from './index.html';
+
+document.body.append(Template({}, { format: 'fragment' }));
+```
+
+Or to take the first element from that fragment:
+
+```js
+import Template from './index.html';
+
+document.body.append(Template({}, { format: 'element' }));
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,15 @@
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -4347,20 +4356,31 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
-      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -4990,11 +5010,9 @@
       }
     },
     "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "optional": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.1.tgz",
+      "integrity": "sha512-w+MMxnByppM4jwskitZotEtvtO3a2C7WOz31NxJToGisHuysCAQQU7umb/pA/6soPFe8LGjXFEFbuPuLEPm7Ag=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -9189,6 +9207,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -9197,7 +9216,8 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         }
       }
     },
@@ -11120,7 +11140,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,12 @@
     "url": "https://github.com/mixmaxhq/rollup-plugin-handlebars-plus/issues"
   },
   "homepage": "https://github.com/mixmaxhq/rollup-plugin-handlebars-plus#readme",
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "dependencies": {
-    "handlebars": "^4.3.0"
+    "handlebars": "^4.7.6",
+    "jsesc": "^3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",


### PR DESCRIPTION
Support an explicit `format` option and new functionality for the format values of `element` and `fragment`. Also support the default module id of `jquery` when supporting the `jquery` format.

BREAKING CHANGE: mostly backwards compatible, but some edge cases related to formats that might crop up; it's best to just update the template invocations to use the format option intentionally.

#### Potential Risks

- Could break existing argument forms, though these have mostly been tested.

#### Test Plan

- [ ] Validate on internal codebases.

#### Checklist
- [ ] ~I've increased test coverage~
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.