### PR TITLE
feat: mark generated Templates as pure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ function handlebars(options) {
         body += `import '${escapePath(partial)}${options.templateExtension}';\n`;
       }
 
-      body += `var Template = Handlebars.template(${template});\n`;
+      body += `var Template = /*#__PURE__*/Handlebars.template(${template});\n`;
 
       if (options.isPartial(name)) {
         let partialName = id;


### PR DESCRIPTION
This lets tools like Terser understand it can trim out any unused templates - especially useful for libraries that ship a bunch of templates that are only conditionally necessary.